### PR TITLE
CI: Run workflow on PRs and ensure latest formatted code in Lint, Test, and Build

### DIFF
--- a/.github/workflows/FormatLintTestBuild.yml
+++ b/.github/workflows/FormatLintTestBuild.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '17'
-          java-package: jdk+fx
+          distribution: 'jdk+fx'
 
       - name: Download google-java-format
         run: |
@@ -34,25 +34,41 @@ jobs:
         run: |
           git config --global user.name "Auto Formatter"
           git config --global user.email "auto_formatter@gmail.com"
-          git add .
-          git commit -m "Apply google-java-format to Java files" || echo "No changes to commit"
 
-      - name: Push changes
-        run: |
-          git push
+          # Check if there are any changes
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add .
+            git commit -m "Apply google-java-format to Java files"
+            git push
+            echo "CHANGES_PUSHED=true" >> $GITHUB_ENV
+          else
+            echo "No formatting changes detected."
+            echo "CHANGES_PUSHED=false" >> $GITHUB_ENV
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: Lint Code Base
     runs-on: ubuntu-latest
-    needs: format  # Runs only after formatting
+    needs: format
+    if: always() 
     steps:
-      - name: Checkout code
+      - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-  
+          ref: ${{ github.head_ref }}
+
+      - name: Detect and pull latest changes from the same branch
+        run: |
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          echo "Current branch: $BRANCH_NAME"
+          git fetch origin $BRANCH_NAME  # Fetch the latest changes from the current branch
+          git reset --hard origin/$BRANCH_NAME  # Ensure we are using the latest commit from the branch
+          git log -1  # Show latest commit for debugging
+
+
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
@@ -63,24 +79,30 @@ jobs:
           VALIDATE_JAVA: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show environment variables for debugging
-        run: echo "LINTER_RULES_PATH=${{ env.LINTER_RULES_PATH }}"
-
   test:
     name: Run Tests with Gradle
     runs-on: ubuntu-latest
-    needs: lint  # Runs only after linting
+    needs: lint
     steps:
-      - name: Checkout code
+      - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Detect and pull latest changes from the same branch
+        run: |
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          echo "Current branch: $BRANCH_NAME"
+          git fetch origin $BRANCH_NAME  # Fetch the latest changes from the current branch
+          git reset --hard origin/$BRANCH_NAME  # Ensure we are using the latest commit from the branch
+          git log -1  # Show latest commit for debugging
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: '17'
-          java-package: jdk+fx
+          distribution: 'jdk+fx'
 
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
@@ -91,24 +113,33 @@ jobs:
   build:
     name: Build & Upload JAR
     runs-on: ubuntu-latest
-    needs: test  # Runs only after tests pass
+    needs: test
     steps:
-      - name: Checkout code
+      - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Detect and pull latest changes from the same branch
+        run: |
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          echo "Current branch: $BRANCH_NAME"
+          git fetch origin $BRANCH_NAME  # Fetch the latest changes from the current branch
+          git reset --hard origin/$BRANCH_NAME  # Ensure we are using the latest commit from the branch
+          git log -1  # Show latest commit for debugging
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: '17'
-          java-package: jdk+fx
+          distribution: 'jdk+fx'
 
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
 
       - name: Build JAR without Checkstyle
-        run: ./gradlew build -x checkstyleMain -x checkstyleTest # Skip Checkstyle, since it is done earlier
+        run: ./gradlew build -x checkstyleMain -x checkstyleTest
 
       - name: Find JAR File
         run: |
@@ -119,4 +150,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: javatro-jar
-          path: ${{ env.JAR_PATH }}  # Upload the JAR file
+          path: ${{ env.JAR_PATH }}

--- a/.github/workflows/FormatLintTestBuild.yml
+++ b/.github/workflows/FormatLintTestBuild.yml
@@ -1,6 +1,6 @@
 name: Auto Java Formatter
 
-on: push
+on: [push,pull_request]
 
 permissions:
   contents: write

--- a/.github/workflows/FormatLintTestBuild.yml
+++ b/.github/workflows/FormatLintTestBuild.yml
@@ -2,7 +2,7 @@ name: Auto Java Formatter
 
 on:
   push:
-  pull_request:
+  pull_request_target:
     branches:
       - master  # Adjust to match the main branch of your upstream repo
 

--- a/.github/workflows/FormatLintTestBuild.yml
+++ b/.github/workflows/FormatLintTestBuild.yml
@@ -1,6 +1,10 @@
 name: Auto Java Formatter
 
-on: [push,pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      - master  # Adjust to match the main branch of your upstream repo
 
 permissions:
   contents: write
@@ -11,16 +15,17 @@ jobs:
     name: Auto Java Formatter
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}  # Handles both push & PR
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: '17'
-          distribution: 'jdk+fx'
+          distribution: 'temurin'
 
       - name: Download google-java-format
         run: |
@@ -29,6 +34,18 @@ jobs:
       - name: Fix Java formatting with google-java-format
         run: |
           java --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED -jar /tmp/google-java-format.jar -a --replace $(find . -name "*.java")
+
+      - name: Ensure branch is correct for push
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BRANCH_NAME=${{ github.head_ref }}
+            echo "Switching back to PR branch: $BRANCH_NAME"
+            git checkout -b $BRANCH_NAME  # Create and switch to the branch
+          else
+            BRANCH_NAME=${{ github.ref_name }}
+            echo "Push event detected, staying on branch: $BRANCH_NAME"
+          fi
+          echo "Final branch: $(git branch --show-current)"
 
       - name: Commit formatted code
         run: |
@@ -39,7 +56,7 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             git add .
             git commit -m "Apply google-java-format to Java files"
-            git push
+            git push origin $BRANCH_NAME  # Push back to the correct branch
             echo "CHANGES_PUSHED=true" >> $GITHUB_ENV
           else
             echo "No formatting changes detected."
@@ -52,22 +69,13 @@ jobs:
     name: Lint Code Base
     runs-on: ubuntu-latest
     needs: format
-    if: always() 
+    if: always()
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-
-      - name: Detect and pull latest changes from the same branch
-        run: |
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          echo "Current branch: $BRANCH_NAME"
-          git fetch origin $BRANCH_NAME  # Fetch the latest changes from the current branch
-          git reset --hard origin/$BRANCH_NAME  # Ensure we are using the latest commit from the branch
-          git log -1  # Show latest commit for debugging
-
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
 
       - name: Lint Code Base
         uses: github/super-linter@v4
@@ -83,26 +91,19 @@ jobs:
     name: Run Tests with Gradle
     runs-on: ubuntu-latest
     needs: lint
+    if: always()
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-
-      - name: Detect and pull latest changes from the same branch
-        run: |
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          echo "Current branch: $BRANCH_NAME"
-          git fetch origin $BRANCH_NAME  # Fetch the latest changes from the current branch
-          git reset --hard origin/$BRANCH_NAME  # Ensure we are using the latest commit from the branch
-          git log -1  # Show latest commit for debugging
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: '17'
-          distribution: 'jdk+fx'
+          distribution: 'temurin'
 
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
@@ -114,26 +115,19 @@ jobs:
     name: Build & Upload JAR
     runs-on: ubuntu-latest
     needs: test
+    if: always()
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-
-      - name: Detect and pull latest changes from the same branch
-        run: |
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          echo "Current branch: $BRANCH_NAME"
-          git fetch origin $BRANCH_NAME  # Fetch the latest changes from the current branch
-          git reset --hard origin/$BRANCH_NAME  # Ensure we are using the latest commit from the branch
-          git log -1  # Show latest commit for debugging
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: '17'
-          distribution: 'jdk+fx'
+          distribution: 'temurin'
 
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew

--- a/.github/workflows/FormatLintTestBuild.yml
+++ b/.github/workflows/FormatLintTestBuild.yml
@@ -15,11 +15,12 @@ jobs:
     name: Auto Java Formatter
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout latest code
+      - name: Checkout latest code from fork
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}  # Handles both push & PR
+          repository: ${{ github.event.pull_request.head.repo.full_name }}  # Ensures fork is used
+          ref: ${{ github.event.pull_request.head.ref }}  # Uses the correct branch from the fork
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
@@ -71,11 +72,12 @@ jobs:
     needs: format
     if: always()
     steps:
-      - name: Checkout latest code
+      - name: Checkout latest code from fork
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}  # Ensures fork is used
+          ref: ${{ github.event.pull_request.head.ref }}  # Uses the correct branch from the fork
 
       - name: Lint Code Base
         uses: github/super-linter@v4
@@ -93,11 +95,12 @@ jobs:
     needs: lint
     if: always()
     steps:
-      - name: Checkout latest code
+      - name: Checkout latest code from fork
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}  # Ensures fork is used
+          ref: ${{ github.event.pull_request.head.ref }}  # Uses the correct branch from the fork
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1
@@ -117,11 +120,12 @@ jobs:
     needs: test
     if: always()
     steps:
-      - name: Checkout latest code
+      - name: Checkout latest code from fork
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}  # Ensures fork is used
+          ref: ${{ github.event.pull_request.head.ref }}  # Uses the correct branch from the fork
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1

--- a/src/main/java/Javatro/PokerHand.java
+++ b/src/main/java/Javatro/PokerHand.java
@@ -18,8 +18,7 @@ public class PokerHand {
         // Counts occurrences of each suit.
         Map<Card.Suit, Integer> suitCount = new HashMap<>();
 
-        // card.rank() retrieves the rank of the card (e.g., Rank.ACE, Rank.KING, Rank.TEN, etc.).
-        // rankCount.getOrDefault(card.rank(), 0) checks if the rank is already in the map:
+        // card.rank() retrieves the rank of the card (e.g., Rank.ACE, Rank.KING, Rank.TEN, etc.). rankCount.getOrDefault(card.rank(), 0) checks if the rank is already in the map:
         //   - If yes, it gets the current count.
         //   - If not, it returns 0 (default value).
         // +1 increments the count for that rank.

--- a/src/main/java/Javatro/PokerHand.java
+++ b/src/main/java/Javatro/PokerHand.java
@@ -18,7 +18,8 @@ public class PokerHand {
         // Counts occurrences of each suit.
         Map<Card.Suit, Integer> suitCount = new HashMap<>();
 
-        // card.rank() retrieves the rank of the card (e.g., Rank.ACE, Rank.KING, Rank.TEN, etc.). rankCount.getOrDefault(card.rank(), 0) checks if the rank is already in the map:
+        // card.rank() retrieves the rank of the card (e.g., Rank.ACE, Rank.KING, Rank.TEN, etc.). 
+        //rankCount.getOrDefault(card.rank(), 0) checks if the rank is already in the map:
         //   - If yes, it gets the current count.
         //   - If not, it returns 0 (default value).
         // +1 increments the count for that rank.

--- a/src/main/java/Javatro/PokerHand.java
+++ b/src/main/java/Javatro/PokerHand.java
@@ -18,8 +18,8 @@ public class PokerHand {
         // Counts occurrences of each suit.
         Map<Card.Suit, Integer> suitCount = new HashMap<>();
 
-        // card.rank() retrieves the rank of the card (e.g., Rank.ACE, Rank.KING, Rank.TEN, etc.). 
-        //rankCount.getOrDefault(card.rank(), 0) checks if the rank is already in the map:
+        // card.rank() retrieves the rank of the card (e.g., Rank.ACE, Rank.KING, Rank.TEN, etc.).
+        // rankCount.getOrDefault(card.rank(), 0) checks if the rank is already in the map:
         //   - If yes, it gets the current count.
         //   - If not, it returns 0 (default value).
         // +1 increments the count for that rank.


### PR DESCRIPTION
### Summary
This PR updates the CI/CD workflow to improve reliability and visibility of test results. It ensures that:
1. The workflow runs when a pull request is opened to the main repository, allowing maintainers to see test results before merging.
2. The Lint, Test, and Build steps always use the latest formatted code after the auto-formatter makes changes.

### Changes Made
- Added `pull_request` trigger to run workflows on PRs targeting the main repository.
- Modified CI/CD steps to fetch the latest formatted code before running Lint, Test, and Build.
- Ensured test results are displayed in the PR for maintainers to review.

### Justification
Previously:
- CI/CD only ran on pushes within the forked repository, making it difficult for maintainers to validate PRs.
- Lint, Test, and Build steps could run on outdated code if the formatter made changes, causing inconsistencies.
With this update, the workflow now runs reliably in PRs and always operates on the latest formatted code.

### Testing
- Verified that the workflow triggers correctly on PR creation.
- Ensured that Lint, Test, and Build steps fetch the latest commit after formatting.
- Confirmed that test results appear in the PR view of the main repository.

This improves CI/CD visibility and ensures all PRs meet formatting and testing standards before merging.
