### PR TITLE
Fix HoldingHand Play() and Discard()

### DIFF
--- a/src/main/java/Javatro/HoldingHand.java
+++ b/src/main/java/Javatro/HoldingHand.java
@@ -1,7 +1,10 @@
 package Javatro;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /*
  * Tracks the 8 cards held in a hand
@@ -9,10 +12,12 @@ import java.util.List;
  */
 
 public class HoldingHand {
-    protected List<Card> Hand;
     private final int HOLDING_LIMIT = 8; // The maximum number of cards a hand can hold
+    protected List<Card> Hand;
 
-    /** Instantiate an empty List of Cards. */
+    /**
+     * Instantiate an empty List of Cards.
+     */
     public HoldingHand() {
         Hand = new ArrayList<Card>();
     }
@@ -34,7 +39,7 @@ public class HoldingHand {
      * Draws a specified number of cards from the deck and adds them to the Hand.
      *
      * @param numberOfDraws The number of cards to draw from the deck
-     * @param deck Deck containing the remaining cards
+     * @param deck          Deck containing the remaining cards
      */
     public void draw(int numberOfDraws, Deck deck) {
         for (int i = 0; i < numberOfDraws; i++) {
@@ -55,29 +60,47 @@ public class HoldingHand {
      * <p>This function should not be called if there are no cards played.
      *
      * @param cardsToPlay List containing cards to be played
-     * @param deck Deck containing the remaining cards
+     * @param deck        Deck containing the remaining cards
      */
-    public List<Card> play(List<Integer> cardsToPlay, Deck deck) {
-        if (cardsToPlay.size() > 5) {
-            System.out.println(
-                    "Number of cards played "
-                            + "("
-                            + cardsToPlay.size()
-                            + ")"
-                            + "exceeds the maximum allowed. (5)");
-            return null;
-        }
-
+    public List<Card> play(List<Integer> cardsToPlay, Deck deck) throws JavatroException {
         List<Card> playList = new ArrayList<>();
-        for (int play : cardsToPlay) {
-            Card card = Hand.remove(play);
-            playList.add(card);
+
+        //Validate that cardsToPlay and the played card positions are valid inputs
+        if (cardsToPlay.size() > 5) {
+            throw new JavatroException("Number of cards played " + "(" +
+                    cardsToPlay.size() + ")" + "exceeds maximum allowed. (5)");
+        } else {
+            for (int index : cardsToPlay) {
+                if (index < 0 || index >= Hand.size()) {
+                    throw new JavatroException("Invalid index in cardsToPlay: " + index);
+                }
+            }
         }
 
+        // Create a set to mark indices for removal
+        Set<Integer> indicesToRemove = new HashSet<>(cardsToPlay);
+
+        //Add cards that should be played in order of cardsToPlay
+        for (int index : cardsToPlay) {
+            if (indicesToRemove.contains(index)) {
+                Card card = Hand.get(index);
+                playList.add(card);
+            }
+        }
+
+        // Remove the cardsToPlay from the Hand in descending order of indices
+        List<Integer> sortedToRemove = new ArrayList<>(indicesToRemove);
+        sortedToRemove.sort(Comparator.reverseOrder());
+        for (int index : sortedToRemove) {
+            Hand.remove(index);
+        }
+
+        // Draw the same number of cards played
         for (int i = 0; i < cardsToPlay.size(); i++) {
             Card tempCard = deck.draw();
             Hand.add(tempCard);
         }
+
         return playList;
     }
 
@@ -86,11 +109,28 @@ public class HoldingHand {
      * left is 0.
      *
      * @param cardsToDiscard List containing the cards at specified positions to be discarded
-     * @param deck Deck containing the remaining cards
+     * @param deck           Deck containing the remaining cards
      */
-    public void discard(List<Integer> cardsToDiscard, Deck deck) {
-        for (int discard : cardsToDiscard) {
-            Hand.remove(discard);
+    public void discard(List<Integer> cardsToDiscard, Deck deck) throws JavatroException {
+
+        //Validate that cardsToDiscard and the played card positions are valid inputs
+        if (cardsToDiscard.size() > 5) {
+            throw new JavatroException("Number of cards discarded " + "(" +
+                    cardsToDiscard.size() + ")" + "exceeds maximum allowed. (5)");
+        } else {
+            for (int index : cardsToDiscard) {
+                if (index < 0 || index >= Hand.size()) {
+                    throw new JavatroException("Invalid index in cardsToPlay: " + index);
+                }
+            }
+        }
+
+
+        // Remove the cardsToPlay from the Hand in descending order of indices
+        List<Integer> sortedToRemove = new ArrayList<>(cardsToDiscard);
+        sortedToRemove.sort(Comparator.reverseOrder());
+        for (int index : sortedToRemove) {
+            Hand.remove(index);
         }
 
         // Draw the same number of cards discarded

--- a/src/main/java/Javatro/HoldingHand.java
+++ b/src/main/java/Javatro/HoldingHand.java
@@ -74,7 +74,7 @@ public class HoldingHand {
         } else {
             for (int index : cardsToPlay) {
                 if (index < 0 || index >= Hand.size()) {
-                    throw new JavatroException("Invalid index in cardsToPlay: " + index);
+                    throw new JavatroException("Invalid index in cards to be played: " + index);
                 }
             }
         }
@@ -126,7 +126,7 @@ public class HoldingHand {
         } else {
             for (int index : cardsToDiscard) {
                 if (index < 0 || index >= Hand.size()) {
-                    throw new JavatroException("Invalid index in cardsToPlay: " + index);
+                    throw new JavatroException("Invalid index in cards to be discarded: " + index);
                 }
             }
         }

--- a/src/main/java/Javatro/HoldingHand.java
+++ b/src/main/java/Javatro/HoldingHand.java
@@ -12,8 +12,8 @@ import java.util.Set;
  */
 
 public class HoldingHand {
-    protected List<Card> Hand;
     private final int HOLDING_LIMIT = 8; // The maximum number of cards a hand can hold
+    protected List<Card> Hand;
 
     /** Instantiate an empty List of Cards. */
     public HoldingHand() {

--- a/src/main/java/Javatro/HoldingHand.java
+++ b/src/main/java/Javatro/HoldingHand.java
@@ -15,9 +15,7 @@ public class HoldingHand {
     private final int HOLDING_LIMIT = 8; // The maximum number of cards a hand can hold
     protected List<Card> Hand;
 
-    /**
-     * Instantiate an empty List of Cards.
-     */
+    /** Instantiate an empty List of Cards. */
     public HoldingHand() {
         Hand = new ArrayList<Card>();
     }
@@ -39,7 +37,7 @@ public class HoldingHand {
      * Draws a specified number of cards from the deck and adds them to the Hand.
      *
      * @param numberOfDraws The number of cards to draw from the deck
-     * @param deck          Deck containing the remaining cards
+     * @param deck Deck containing the remaining cards
      */
     public void draw(int numberOfDraws, Deck deck) {
         for (int i = 0; i < numberOfDraws; i++) {
@@ -60,15 +58,19 @@ public class HoldingHand {
      * <p>This function should not be called if there are no cards played.
      *
      * @param cardsToPlay List containing cards to be played
-     * @param deck        Deck containing the remaining cards
+     * @param deck Deck containing the remaining cards
      */
     public List<Card> play(List<Integer> cardsToPlay, Deck deck) throws JavatroException {
         List<Card> playList = new ArrayList<>();
 
-        //Validate that cardsToPlay and the played card positions are valid inputs
+        // Validate that cardsToPlay and the played card positions are valid inputs
         if (cardsToPlay.size() > 5) {
-            throw new JavatroException("Number of cards played " + "(" +
-                    cardsToPlay.size() + ")" + "exceeds maximum allowed. (5)");
+            throw new JavatroException(
+                    "Number of cards played "
+                            + "("
+                            + cardsToPlay.size()
+                            + ")"
+                            + "exceeds maximum allowed. (5)");
         } else {
             for (int index : cardsToPlay) {
                 if (index < 0 || index >= Hand.size()) {
@@ -80,7 +82,7 @@ public class HoldingHand {
         // Create a set to mark indices for removal
         Set<Integer> indicesToRemove = new HashSet<>(cardsToPlay);
 
-        //Add cards that should be played in order of cardsToPlay
+        // Add cards that should be played in order of cardsToPlay
         for (int index : cardsToPlay) {
             if (indicesToRemove.contains(index)) {
                 Card card = Hand.get(index);
@@ -109,14 +111,18 @@ public class HoldingHand {
      * left is 0.
      *
      * @param cardsToDiscard List containing the cards at specified positions to be discarded
-     * @param deck           Deck containing the remaining cards
+     * @param deck Deck containing the remaining cards
      */
     public void discard(List<Integer> cardsToDiscard, Deck deck) throws JavatroException {
 
-        //Validate that cardsToDiscard and the played card positions are valid inputs
+        // Validate that cardsToDiscard and the played card positions are valid inputs
         if (cardsToDiscard.size() > 5) {
-            throw new JavatroException("Number of cards discarded " + "(" +
-                    cardsToDiscard.size() + ")" + "exceeds maximum allowed. (5)");
+            throw new JavatroException(
+                    "Number of cards discarded "
+                            + "("
+                            + cardsToDiscard.size()
+                            + ")"
+                            + "exceeds maximum allowed. (5)");
         } else {
             for (int index : cardsToDiscard) {
                 if (index < 0 || index >= Hand.size()) {
@@ -124,7 +130,6 @@ public class HoldingHand {
                 }
             }
         }
-
 
         // Remove the cardsToPlay from the Hand in descending order of indices
         List<Integer> sortedToRemove = new ArrayList<>(cardsToDiscard);

--- a/src/main/java/Javatro/HoldingHand.java
+++ b/src/main/java/Javatro/HoldingHand.java
@@ -12,8 +12,8 @@ import java.util.Set;
  */
 
 public class HoldingHand {
-    private final int HOLDING_LIMIT = 8; // The maximum number of cards a hand can hold
     protected List<Card> Hand;
+    private final int HOLDING_LIMIT = 8; // The maximum number of cards a hand can hold
 
     /** Instantiate an empty List of Cards. */
     public HoldingHand() {

--- a/src/main/java/Javatro/Round.java
+++ b/src/main/java/Javatro/Round.java
@@ -85,7 +85,7 @@ public class Round {
      * @param cardIndices Indices of cards to discard from the holding hand
      * @throws IllegalStateException If no remaining discards are available
      */
-    public void discardCards(List<Integer> cardIndices) {
+    public void discardCards(List<Integer> cardIndices) throws JavatroException {
         if (remainingDiscards <= 0) {
             throw new IllegalStateException("No remaining discards available");
         }

--- a/src/test/java/Javatro/HoldingHandTest.java
+++ b/src/test/java/Javatro/HoldingHandTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class HoldingHandTest {
 
-    //Test deck add, draw functions
+    // Test deck add, draw functions
     @Test
     void testDeck() throws JavatroException {
         Deck deck = new Deck();
@@ -18,7 +18,7 @@ public class HoldingHandTest {
         assertEquals(51, deck.getRemainingCards());
     }
 
-    //Test HoldingHand add, draw, and discard functions
+    // Test HoldingHand add, draw, and discard functions
     @Test
     void testHoldingHand() throws JavatroException {
         Deck deck = new Deck();

--- a/src/test/java/Javatro/HoldingHandTest.java
+++ b/src/test/java/Javatro/HoldingHandTest.java
@@ -8,8 +8,9 @@ import java.util.List;
 
 public class HoldingHandTest {
 
+    //Test deck add, draw functions
     @Test
-    void testDeck() {
+    void testDeck() throws JavatroException {
         Deck deck = new Deck();
         int cardsRemaining = deck.getRemainingCards();
         assertEquals(52, cardsRemaining);
@@ -17,8 +18,9 @@ public class HoldingHandTest {
         assertEquals(51, deck.getRemainingCards());
     }
 
+    //Test HoldingHand add, draw, and discard functions
     @Test
-    void testHoldingHand() {
+    void testHoldingHand() throws JavatroException {
         Deck deck = new Deck();
         HoldingHand holdingHand = new HoldingHand();
         for (int i = 0; i < 8; i++) {


### PR DESCRIPTION
This PR fixes #62, while also adding `JavatroExceptions` for the `HoldingHand` class.

#62 was caused by `Hand` index positions shifting after every `Card` was removed, resulting in cards being played and discarded being incorrect. This PR fixes the issue by changing the logic flow.

Cards that should be removed are now removed in descending order when sorted. This eliminates the problem of index positions being shifted.

``` 
        List<Integer> sortedToRemove = new ArrayList<>(cardsToDiscard);
        sortedToRemove.sort(Comparator.reverseOrder());
        for (int index : sortedToRemove) {
            Hand.remove(index);
        }

```

For play(), cards that should be played use `Hand.get()` instead of `Hand.remove()` before the card removal step. This preserves the order of cards being played.

```
        // Add cards that should be played in order of cardsToPlay
        for (int index : cardsToPlay) {
            if (indicesToRemove.contains(index)) {
                Card card = Hand.get(index);
                playList.add(card);
            }
        }
```
