### PR TITLE
Fix Discards for HoldingHand

### DIFF
--- a/src/main/java/javatro/core/Round.java
+++ b/src/main/java/javatro/core/Round.java
@@ -20,8 +20,8 @@ public class Round {
     /** The player's current held jokers. */
     public HeldJokers playerJokers;
 
-    /** The cards played in the current round. */
-    private List<Card> playedCards;
+    /** The cards previously played/discarded in the current round. */
+    private List<Card> chosenCards;
 
     /** The state of the current round. */
     private final RoundState state;
@@ -157,7 +157,7 @@ public class Round {
      * @see RoundActions#playCards(List)
      */
     public void playCards(List<Integer> cardIndices) throws JavatroException {
-        playedCards = actions.playCards(cardIndices);
+        chosenCards = actions.playCards(cardIndices);
     }
 
     /**
@@ -168,7 +168,7 @@ public class Round {
      * @see RoundActions#discardCards(List)
      */
     public void discardCards(List<Integer> cardIndices) throws JavatroException {
-        actions.discardCards(cardIndices);
+        chosenCards = actions.discardCards(cardIndices);
     }
 
     /**
@@ -314,7 +314,7 @@ public class Round {
      * @return The round actions object
      */
     public List<Card> getPlayedCards() {
-        return playedCards;
+        return chosenCards;
     }
 
     /**
@@ -324,6 +324,6 @@ public class Round {
      * @throws JavatroException If the played cards are invalid or empty
      */
     public PokerHand getPlayedHand() throws JavatroException {
-        return HandResult.evaluateHand(playedCards);
+        return HandResult.evaluateHand(chosenCards);
     }
 }

--- a/src/main/java/javatro/core/RoundActions.java
+++ b/src/main/java/javatro/core/RoundActions.java
@@ -73,7 +73,7 @@ public class RoundActions {
      * @param cardIndices Indices of cards to discard from the holding hand
      * @throws JavatroException If the discard is invalid
      */
-    public void discardCards(List<Integer> cardIndices) throws JavatroException {
+    public List<Card> discardCards(List<Integer> cardIndices) throws JavatroException {
         RoundState state = round.getState();
         Integer numberOfDiscards = cardIndices.size();
 
@@ -102,7 +102,7 @@ public class RoundActions {
         int oldRemainingDiscards = state.getRemainingDiscards();
 
         // Execute discard
-        round.playerHand.discard(cardIndices);
+        List<Card> discardedCards = round.playerHand.discard(cardIndices);
         state.decrementDiscards();
         round.playerHand.draw(indicesToDiscard.size(), Round.deck);
 
@@ -112,5 +112,6 @@ public class RoundActions {
                 : "Hand size should be maintained after discard";
 
         round.updateRoundVariables();
+        return discardedCards;
     }
 }

--- a/src/main/java/javatro/display/screens/GameScreen.java
+++ b/src/main/java/javatro/display/screens/GameScreen.java
@@ -137,7 +137,7 @@ public class GameScreen extends Screen implements PropertyChangeListener {
         // --- Deck Name / Jokers / Holding Hand ---
         List<String> extraContent = new ArrayList<>();
         extraContent.add("Current Deck:");
-        extraContent.add("Deck Name");
+        extraContent.add(JavatroCore.deck.getDeckName().getName());
         extraContent.add("");
         extraContent.add("");
         extraContent.add("Jokers' Effects:");


### PR DESCRIPTION
The main focus of this PR is to fix #117, while adding the deck name to be displayed.

Upon discarding a hand, the chosen cards were not showing up, and an unexpected error demonstrated in #177 was showing up. It occured regardless of the number of cards played. Additionally, the `GameScreen` also failed to display, only showing options available. 

This bug occurred due to discards returning the cards, causing a null exception to occur. This has been fixed by changing the `discardCards()` in `RoundActions` to also return a `List` of Cards.