### PR TITLE
Link boss blinds to GameScreen 

### DIFF
--- a/src/main/java/javatro/core/Ante.java
+++ b/src/main/java/javatro/core/Ante.java
@@ -1,6 +1,6 @@
 package javatro.core;
 
-// @author swethaiscool
+// @author swethacool
 /**
  * The {@code Ante} class represents the ante system in a poker game, managing the current round,
  * ante values, and blind progression.

--- a/src/main/java/javatro/core/Round.java
+++ b/src/main/java/javatro/core/Round.java
@@ -8,18 +8,56 @@ import java.util.List;
 
 /** Represents a round in the Javatro game. */
 public class Round {
+
+    //@@author K-J-Q
     /** The type of boss in the round. */
     public enum BossType {
-        NONE,
-        THE_NEEDLE,
-        THE_WATER,
-        THE_CLUB,
-        THE_WINDOW,
-        THE_HEAD,
-        THE_GOAD,
-        THE_PLANT,
-        THE_PSYCHIC
+        NONE("",""),
+        THE_NEEDLE("The Needle", "Play only 1 hand"),
+        THE_WATER("The Water", "Start with 0 discards"),
+        THE_CLUB("The Club", "All Club cards cannot score"),
+        THE_WINDOW("The Window","All Club cards cannot score"),
+        THE_HEAD("The Head","All Diamond cards cannot score"),
+        THE_GOAD("The Goad","All Spade cards cannot score"),
+        THE_PLANT("The Plant","All face cards cannot score"),
+        THE_PSYCHIC("The Psychic","Must play 5 cards (not all cards need to score)");
+
+        private final String name;
+
+        private final String description;
+
+        /**
+         * Constructs a BossType with the given description.
+         *
+         * @param name The name of the BossType.
+         * @param description The description of the BossType.
+         */
+        BossType(String name, String description) {
+            this.name = name;
+            this.description = description;
+        }
+
+        /**
+         * Returns the name of the BossType.
+         *
+         * @return The name of the BossType.
+         */
+        public String getName() {
+            return name;
+        }
+
+
+        /**
+         * Returns the description of the BossType.
+         *
+         * @return The description of the BossType.
+         */
+        public String getDescription() {
+            return description;
+        }
+
     }
+    //@@author K-J-Q
 
     /** The initial number of cards dealt to the player. */
     public static final int INITIAL_HAND_SIZE = 8;
@@ -149,6 +187,8 @@ public class Round {
     private void applyAnteInvariants(Ante ante) {
         if (ante.getBlind() == Ante.Blind.BOSS_BLIND) {
             this.bossType = getRandomBoss();
+            this.config.setRoundName(this.bossType.name);
+            this.config.setRoundDescription(this.bossType.getDescription());
         }
     }
 

--- a/src/main/java/javatro/core/Round.java
+++ b/src/main/java/javatro/core/Round.java
@@ -9,18 +9,18 @@ import java.util.List;
 /** Represents a round in the Javatro game. */
 public class Round {
 
-    //@@author K-J-Q
+    // @@author K-J-Q
     /** The type of boss in the round. */
     public enum BossType {
-        NONE("",""),
+        NONE("", ""),
         THE_NEEDLE("The Needle", "Play only 1 hand"),
         THE_WATER("The Water", "Start with 0 discards"),
         THE_CLUB("The Club", "All Club cards cannot score"),
-        THE_WINDOW("The Window","All Club cards cannot score"),
-        THE_HEAD("The Head","All Diamond cards cannot score"),
-        THE_GOAD("The Goad","All Spade cards cannot score"),
-        THE_PLANT("The Plant","All face cards cannot score"),
-        THE_PSYCHIC("The Psychic","Must play 5 cards (not all cards need to score)");
+        THE_WINDOW("The Window", "All Club cards cannot score"),
+        THE_HEAD("The Head", "All Diamond cards cannot score"),
+        THE_GOAD("The Goad", "All Spade cards cannot score"),
+        THE_PLANT("The Plant", "All face cards cannot score"),
+        THE_PSYCHIC("The Psychic", "Must play 5 cards (not all cards need to score)");
 
         private final String name;
 
@@ -46,7 +46,6 @@ public class Round {
             return name;
         }
 
-
         /**
          * Returns the description of the BossType.
          *
@@ -55,9 +54,8 @@ public class Round {
         public String getDescription() {
             return description;
         }
-
     }
-    //@@author K-J-Q
+    // @@author K-J-Q
 
     /** The initial number of cards dealt to the player. */
     public static final int INITIAL_HAND_SIZE = 8;

--- a/src/main/java/javatro/display/screens/BlindSelectScreen.java
+++ b/src/main/java/javatro/display/screens/BlindSelectScreen.java
@@ -10,7 +10,7 @@ import javatro.manager.options.RejectBlindOption;
 import java.util.ArrayList;
 import java.util.List;
 
-// @@author swethaiscool
+// @@author swethacool
 
 /**
  * Represents the screen for selecting the blind in the game. This screen provides options to accept

--- a/src/main/java/javatro/display/screens/GameScreen.java
+++ b/src/main/java/javatro/display/screens/GameScreen.java
@@ -58,7 +58,7 @@ public class GameScreen extends Screen implements PropertyChangeListener {
             colourb = BLUE_B;
         } else if (Objects.equals(roundName, "LARGE BLIND")) {
             colourb = ORANGE_B;
-        } else if (Objects.equals(roundName, "BOSS BLIND")) {
+        } else if (Objects.equals(roundName, JavatroCore.currentRound.getConfig().getRoundName())) {
             colourb = PURPLE_B;
         }
 

--- a/src/main/java/javatro/manager/options/AcceptBlindOption.java
+++ b/src/main/java/javatro/manager/options/AcceptBlindOption.java
@@ -5,7 +5,7 @@ import javatro.core.JavatroException;
 import javatro.display.UI;
 import javatro.manager.JavatroManager;
 
-// @@author swethaiscool
+// @@author swethacool
 /**
  * Represents an option to accept the current blind in the game. This class implements the {@code
  * Option} interface.

--- a/src/main/java/javatro/manager/options/NextRoundOption.java
+++ b/src/main/java/javatro/manager/options/NextRoundOption.java
@@ -7,6 +7,7 @@ import javatro.core.JavatroException;
 import javatro.display.UI;
 import javatro.manager.JavatroManager;
 
+// @@author swethacool
 public class NextRoundOption implements Option {
 
     @Override

--- a/src/main/java/javatro/manager/options/RejectBlindOption.java
+++ b/src/main/java/javatro/manager/options/RejectBlindOption.java
@@ -8,7 +8,7 @@ import javatro.manager.JavatroManager;
 
 import java.util.List;
 
-// @@author swethaiscool
+// @@author swethacool
 /**
  * Represents an option to reject the current blind and move to the next available blind level.
  * Implements the {@code Option} interface.


### PR DESCRIPTION
This PR follows up on #119 and links the Boss Blind names with the `GameScreen`. It also adds descriptions for each Boss Blind Types.