### PR TITLE
Fix Empty Deck Exception not Handled

### DIFF
--- a/src/main/java/javatro/core/Deck.java
+++ b/src/main/java/javatro/core/Deck.java
@@ -33,8 +33,12 @@ public class Deck {
     }
 
     /** Draws and returns a card from the top of the deck */
-    public Card draw() {
-        return deck.remove(0);
+    public Card draw() throws JavatroException {
+        try {
+            return deck.remove(0);
+        } catch (IndexOutOfBoundsException e) {
+            throw JavatroException.noCardsRemaining();
+        }
     }
 
     /** Returns an integer containing the cards left in the deck */

--- a/src/main/java/javatro/core/JavatroException.java
+++ b/src/main/java/javatro/core/JavatroException.java
@@ -81,6 +81,18 @@ public final class JavatroException extends Exception {
     }
 
     /**
+     * Creates an exception indicating the deck is empty.
+     *
+     * <p>This exception is thrown when all the cards in the deck have been drawn.
+     *
+     * @return A {@code JavatroException} indicating the deck is empty.
+     */
+    public static JavatroException noCardsRemaining() {
+        return new JavatroException("Deck is empty.");
+    }
+
+
+    /**
      * Creates an exception indicating no plays remaining.
      *
      * <p>This exception is thrown when the user tries to play cards when no plays are remaining.

--- a/src/main/java/javatro/core/JavatroException.java
+++ b/src/main/java/javatro/core/JavatroException.java
@@ -91,7 +91,6 @@ public final class JavatroException extends Exception {
         return new JavatroException("Deck is empty.");
     }
 
-
     /**
      * Creates an exception indicating no plays remaining.
      *

--- a/src/main/java/javatro/core/Round.java
+++ b/src/main/java/javatro/core/Round.java
@@ -60,7 +60,7 @@ public class Round {
     /** The initial number of cards dealt to the player. */
     public static final int INITIAL_HAND_SIZE = 8;
     /** The maximum number of discards allowed per round. */
-    public static final int MAX_DISCARDS_PER_ROUND = 4;
+    public static final int MAX_DISCARDS_PER_ROUND = 3;
     /** The maximum number of cards in a hand. */
     public static final int DEFAULT_MAX_HAND_SIZE = 5;
     /** The minimum number of cards in a hand. */

--- a/src/test/java/javatro/core/RoundTest.java
+++ b/src/test/java/javatro/core/RoundTest.java
@@ -51,7 +51,7 @@ public class RoundTest {
         assertEquals(remainingPlays, round.getRemainingPlays());
         assertEquals(0, round.getCurrentScore());
         if (ante.getBlind() != Ante.Blind.BOSS_BLIND) {
-            assertEquals(4, round.getRemainingDiscards());
+            assertEquals(3, round.getRemainingDiscards());
         }
         assertFalse(round.isRoundOver());
     }
@@ -247,14 +247,14 @@ public class RoundTest {
         Round round = new Round(ante, 3, deck, heldJokers, "", "");
 
         // Initial state
-        assertEquals(4, round.getRemainingDiscards());
+        assertEquals(3, round.getRemainingDiscards());
         int initialHandSize = round.getPlayerHandCards().size();
 
         // Discard 2 cards
         round.discardCards(List.of(0, 1));
 
         // Check state after discard
-        assertEquals(3, round.getRemainingDiscards());
+        assertEquals(2, round.getRemainingDiscards());
         assertEquals(initialHandSize, round.getPlayerHandCards().size());
     }
 
@@ -266,13 +266,12 @@ public class RoundTest {
         ante.setBlind(Ante.Blind.SMALL_BLIND);
         Round round = new Round(ante, 3, deck, heldJokers, "", "");
 
-        // Use all 4 discards
-        round.discardCards(List.of(0));
+        // Use all 3 discards
         round.discardCards(List.of(0));
         round.discardCards(List.of(0));
         round.discardCards(List.of(0));
 
-        // Fifth discard should fail
+        // Fourth discard should fail
         try {
             round.discardCards(List.of(0));
             fail("Should have thrown an exception for too many discards");
@@ -290,7 +289,7 @@ public class RoundTest {
         Round round = new Round(ante, 3, deck, heldJokers, "", "");
 
         // Initial state
-        assertEquals(4, round.getRemainingDiscards());
+        assertEquals(3, round.getRemainingDiscards());
         int initialHandSize = round.getPlayerHandCards().size();
 
         // Discard 0 cards
@@ -301,7 +300,7 @@ public class RoundTest {
             assertEquals(getExceptionMessage("Cannot discard zero cards"), e.getMessage());
         }
 
-        assertEquals(4, round.getRemainingDiscards());
+        assertEquals(3, round.getRemainingDiscards());
         assertEquals(initialHandSize, round.getPlayerHandCards().size());
     }
 
@@ -331,7 +330,7 @@ public class RoundTest {
         Round round = new Round(ante, 3, deck, heldJokers, "", "");
 
         // Check that default values are maintained
-        assertEquals(4, round.getRemainingDiscards());
+        assertEquals(3, round.getRemainingDiscards());
         assertEquals(Round.DEFAULT_MAX_HAND_SIZE, round.getConfig().getMaxHandSize());
         assertEquals(Round.DEFAULT_MIN_HAND_SIZE, round.getConfig().getMinHandSize());
     }


### PR DESCRIPTION
This PR fixes #128.

It was possible to run out of cards to draw from the deck, specifically for the Abandoned Deck.

This PR fixes this by reducing the `MAX_DISCARDS_PER_ROUND` to 3, matching a standard blind ruleset. An additional `JavatroException` handling this error has also been made.

Tests have also been changed to account for this change in `MAX_DISCARDS_PER_ROUND`